### PR TITLE
Fix move() function

### DIFF
--- a/src/move.py
+++ b/src/move.py
@@ -2,7 +2,7 @@
 import rospy
 from geometry_msgs.msg import Twist
 
-def move(speed,distance,isForward):
+def move():
     # Starts a new node
     rospy.init_node('robot_cleaner', anonymous=True)
     velocity_publisher = rospy.Publisher('/turtle1/cmd_vel', Twist, queue_size=10)


### PR DESCRIPTION
Running the node generates an error because the move() function is defined with three parameters while we call it with no parameters at all.
The parameters are not required in our case because we read them from the terminal.